### PR TITLE
Update npm dependency xmldom

### DIFF
--- a/dist/Jsonix-all.js
+++ b/dist/Jsonix-all.js
@@ -6149,7 +6149,7 @@ if (typeof require === 'function') {
 			// Load the define function via amdefine
 			var define = require('amdefine')(module);
 			// Require xmldom, xmlhttprequest and fs
-			define(["xmldom", "xmlhttprequest", "fs"], _jsonix_factory);
+			define(["@xmldom/xmldom", "xmlhttprequest", "fs"], _jsonix_factory);
 		}
 		else
 		{

--- a/dist/Jsonix-min.js
+++ b/dist/Jsonix-min.js
@@ -2490,7 +2490,7 @@ if (typeof require === 'function') {
 			// Load the define function via amdefine
 			var define = require('amdefine')(module);
 			// Require xmldom, xmlhttprequest and fs
-			define(["xmldom", "xmlhttprequest", "fs"], _jsonix_factory);
+			define(["@xmldom/xmldom", "xmlhttprequest", "fs"], _jsonix_factory);
 		}
 		else
 		{

--- a/nodejs/scripts/jsonix.js
+++ b/nodejs/scripts/jsonix.js
@@ -6149,7 +6149,7 @@ if (typeof require === 'function') {
 			// Load the define function via amdefine
 			var define = require('amdefine')(module);
 			// Require xmldom, xmlhttprequest and fs
-			define(["xmldom", "xmlhttprequest", "fs"], _jsonix_factory);
+			define(["@xmldom/xmldom", "xmlhttprequest", "fs"], _jsonix_factory);
 		}
 		else
 		{

--- a/nodejs/scripts/package-lock.json
+++ b/nodejs/scripts/package-lock.json
@@ -111,6 +111,11 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@xmldom/xmldom": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.0.tgz",
+			"integrity": "sha512-7wVnF+rKrVDEo1xjzkkidTG0grclaVnX0vKa0z9JSXcEdtftUJjvU33jLGg6SHyvs3eeqEsI7jZ6NxYfRypEEg=="
+		},
 		"ajv": {
 			"version": "6.9.1",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
@@ -2514,11 +2519,6 @@
 				"imurmurhash": "^0.1.4",
 				"signal-exit": "^3.0.2"
 			}
-		},
-		"xmldom": {
-			"version": "0.1.27",
-			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-			"integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
 		},
 		"xmlhttprequest": {
 			"version": "1.8.0",

--- a/nodejs/scripts/package.json
+++ b/nodejs/scripts/package.json
@@ -33,10 +33,10 @@
 	"scripts" : {
 		"test" : "nodeunit tests/tests.js"
 	},
-	"dependencies" : {
-		"amdefine" : "0.x.x",
-		"xmldom" : ">=0.1.21",
-		"xmlhttprequest" : "1.x.x"
+	"dependencies": {
+		"@xmldom/xmldom": ">=0.8.0",
+		"amdefine": "0.x.x",
+		"xmlhttprequest": "1.x.x"
 	},
 	"devDependencies" : {
 		"nodeunit" : "0.x.x",

--- a/nodejs/scripts/src/main/npm/package.json
+++ b/nodejs/scripts/src/main/npm/package.json
@@ -35,7 +35,7 @@
 	},
 	"dependencies" : {
 		"amdefine" : "0.x.x",
-		"xmldom" : ">=0.1.21",
+		"@xmldom/xmldom" : ">=0.8.0",
 		"xmlhttprequest" : "1.x.x"
 	},
 	"devDependencies" : {

--- a/nodejs/scripts/tests/sax.js
+++ b/nodejs/scripts/tests/sax.js
@@ -1,5 +1,5 @@
 var fs = require('fs');
-var DOMParser = require('xmldom').DOMParser;
+var DOMParser = require('@xmldom/xmldom').DOMParser;
 module.exports = {
 	parseFromString: function(test) {
 		var Handler = function(){};

--- a/nodejs/scripts/tests/xml.js
+++ b/nodejs/scripts/tests/xml.js
@@ -5,7 +5,7 @@ module.exports =
 	{
 		"Without prefix" : function(test)
 		{
-			var xmldom = require('xmldom');
+			var xmldom = require('@xmldom/xmldom');
 			var di = new (xmldom.DOMImplementation)();
 			var doc = di.createDocument();
 			var element = doc.createElementNS('urn:test', 'test');
@@ -18,7 +18,7 @@ module.exports =
 		},
 		"With Prefix" : function(test)
 		{
-			var xmldom = require('xmldom');
+			var xmldom = require('@xmldom/xmldom');
 			var di = new (xmldom.DOMImplementation)();
 			var doc = di.createDocument();
 			var element = doc.createElementNS('urn:test', 't:test');

--- a/scripts/src/main/javascript/org/hisrc/jsonix/Jsonix/Jsonix.footer.fragmentjs
+++ b/scripts/src/main/javascript/org/hisrc/jsonix/Jsonix/Jsonix.footer.fragmentjs
@@ -11,7 +11,7 @@ if (typeof require === 'function') {
 			// Load the define function via amdefine
 			var define = require('amdefine')(module);
 			// Require xmldom, xmlhttprequest and fs
-			define(["xmldom", "xmlhttprequest", "fs"], _jsonix_factory);
+			define(["@xmldom/xmldom", "xmlhttprequest", "fs"], _jsonix_factory);
 		}
 		else
 		{


### PR DESCRIPTION
Switching from package `xmldom` to `@xmldom/xmldom`, which resolves the (most) security issue present in latest xmldom version 0.6.0:
https://github.com/xmldom/xmldom/security/advisories/GHSA-5fg8-2547-mr8q
Since this jsonix was previously using xmldom@0.1.27 (according to the package-lock.json), there are several other things that improved since that version including [another security issue](https://github.com/xmldom/xmldom/security/advisories/GHSA-h6q6-9hqw-rwfv).
For more details check [our changelog](https://github.com/xmldom/xmldom/blob/master/CHANGELOG.md)
Potentially this also resolves some issues listed in the original repo.

The reason is that the maintainers were forced to switch to a scoped package since 0.7.0:
 https://github.com/xmldom/xmldom/issues/271

- I used node 12 to run `npm install` in `nodejs/scripts`.
- I have no idea how all the testing works in this project and how to setup all the java stuff. It looks like there are quite some windows CLI scripts (`.bat`) I don't have any Windows machine. Please verify everything still works as expected.

I'm one of the xmldom maintainers. Don't hesitate to ask me questions related to xmldom.

PS: I'm aware that you just forked this repo this month, but it's currently the most promising one of all the forks, according to https://useful-forks.github.io/?repo=highsource%2Fjsonix and I hope you will at some point be able to release a new version of the npm package to reduce the number of downloads of our old insecure versions.
There are currently the weekly downloads originiating from the following packages:
- jsonix 1436
- @boundlessgeo/jsonix 302